### PR TITLE
Fix annotation example for Synchronize ConfigMap section on inter-cluster Syncer

### DIFF
--- a/docs/guides/config-syncer/inter-cluster.md
+++ b/docs/guides/config-syncer/inter-cluster.md
@@ -94,7 +94,7 @@ configmap "omni" created
 Now, apply the `kubed.appscode.com/sync-contexts: "context-1,context-2"` annotation to ConfigMap `omni`.
 
 ```console
-$ kubectl annotate configmap omni kubed.appscode.com/sync="context-1,context-2" -n demo
+$ kubectl annotate configmap omni kubed.appscode.com/sync-contexts="context-1,context-2" -n demo
 configmap "omni" annotated
 ```
 


### PR DESCRIPTION
The example command applies `kubed.appscode.com/sync` annotation, while it says `kubed.appscode.com/sync-contexts` above.

Took me like an hour trying to figure whats wrong, then I realized i copy pasted the wrong annotation from the inter-cluster config syncer guide.