### PR TITLE
Fix wrong annotation used on omni ConfigMap

### DIFF
--- a/docs/guides/config-syncer/inter-cluster.md
+++ b/docs/guides/config-syncer/inter-cluster.md
@@ -94,7 +94,7 @@ configmap "omni" created
 Now, apply the `kubed.appscode.com/sync-contexts: "context-1,context-2"` annotation to ConfigMap `omni`.
 
 ```console
-$ kubectl annotate configmap omni kubed.appscode.com/sync="context-1,context-2" -n demo
+$ kubectl annotate configmap omni kubed.appscode.com/sync-contexts="context-1,context-2" -n demo
 configmap "omni" annotated
 ```
 


### PR DESCRIPTION
The  code to add the annotation to get the omni ConfigMap synced across clusters is wrong. It should be `sync-contexts` instead of just `sync`. As, the line above actually also mentions.

Man did this get me confused into why a Secret of mine was not synced to another cluster. I therefore hope you'll accept this small brush up.